### PR TITLE
Fix up abstracting-functions example

### DIFF
--- a/abstracting-functions/abstracting-functions.cabal
+++ b/abstracting-functions/abstracting-functions.cabal
@@ -13,7 +13,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
   build-depends:       base >= 4.7 && < 5,
-                       containers
+                       text
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
I goofed in the `abstracting-functions` example by including an unlawful `Semigroup` instance. This PR simplifies `abstracting-functions` while still keeping the same spirit, but this time, the demonstrated `Semigroup` instance is definitely associative!